### PR TITLE
Bug 1908372 - Remove Alex Vincent's blog

### DIFF
--- a/configs/mozilla.ini
+++ b/configs/mozilla.ini
@@ -87,8 +87,8 @@ name = Marcia Knous
 [http://djst.org/category/mozilla/feed/]
 name = David Tenser
 
-[https://alexvincent.us/blog/?feed=rss2]
-name = Alex Vincent
+#[https://alexvincent.us/blog/?feed=rss2]
+#name = Alex Vincent
 
 [http://weblogs.mozillazine.org/bz/index.rdf]
 name = Boris Zbarsky

--- a/configs/mozilla.ini
+++ b/configs/mozilla.ini
@@ -87,9 +87,6 @@ name = Marcia Knous
 [http://djst.org/category/mozilla/feed/]
 name = David Tenser
 
-#[https://alexvincent.us/blog/?feed=rss2]
-#name = Alex Vincent
-
 [http://weblogs.mozillazine.org/bz/index.rdf]
 name = Boris Zbarsky
 


### PR DESCRIPTION
Website is permanently down and could be taken over by spammers in the future.

Resolves [Bug 1908372](https://bugzilla.mozilla.org/show_bug.cgi?id=1908372).

Creating PR to test whether this is an appreciated way of resolving bugs in [Websites :: planet.mozilla.org](https://bugzilla.mozilla.org/buglist.cgi?product=Websites&component=planet.mozilla.org&bug_status=__open__), due to them not resolved for [~1year](https://bugzilla.mozilla.org/buglist.cgi?chfieldvalue=FIXED&component=planet.mozilla.org&product=Websites&list_id=17180159&chfield=resolution&query_format=advanced&chfieldfrom=-12m). I'd like to add the [Necko Blog](https://bugzilla.mozilla.org/show_bug.cgi?id=1885733), but there are also other blogs open that are likely worth adding.