### PR TITLE
Bug 1885733 - Add Mozilla Necko blog to planet

### DIFF
--- a/configs/mozilla.ini
+++ b/configs/mozilla.ini
@@ -1068,3 +1068,6 @@ name = William Durand
 
 [https://fxdx.dev/feed/]
 name = Firefox Developer Experience
+
+[https://mozilla-necko.github.io/feed.xml]
+name = Mozilla Necko Blog


### PR DESCRIPTION
Insights into Necko - the Firefox Networking team
https://mozilla-necko.github.io/

Resolves [Bug 1885733](https://bugzilla.mozilla.org/show_bug.cgi?id=1885733)