### PR TITLE
Bug 1812056: Add Mozilla Data Team YouTube Channel

### DIFF
--- a/configs/mozilla.ini
+++ b/configs/mozilla.ini
@@ -976,3 +976,6 @@ name = Serge Guelton
 
 [https://cmkm.dev/tags/mozilla/index.xml]
 name = Cieara Meador
+
+[https://www.youtube.com/feeds/videos.xml?channel_id=UCS1zp4AVNvykWzPC-vB_Daw]
+name = Mozilla Data YouTube Channel


### PR DESCRIPTION
Mozilla Data YouTube Channel
https://www.youtube.com/feeds/videos.xml?channel_id=UCS1zp4AVNvykWzPC-vB_Daw

Resolves [Bug 1812056](https://bugzilla.mozilla.org/show_bug.cgi?id=1812056)