### PR TITLE
Bug 1987951: embedded video tags lacks design and break site layout

### DIFF
--- a/themes/mozilla/planet.css
+++ b/themes/mozilla/planet.css
@@ -246,3 +246,10 @@ h4 a {
   border: 1px dashed red !important;
   text-decoration: none !important;
 }
+
+/* Unstyled video tags can break the site layout as they take the whole viewport width */
+video {
+  max-width: 80%;
+  border: 1px solid lightgray;
+  border-radius: 10px;
+}


### PR DESCRIPTION
Before:
<img width="1034" height="854" alt="image" src="https://github.com/user-attachments/assets/98becb7d-8334-49d5-9d66-e522f3ccd8b3" />


After:
<img width="1034" height="854" alt="image" src="https://github.com/user-attachments/assets/5e183bfd-d162-4f6a-a625-832c1879166c" />
